### PR TITLE
Endless loop bug fix

### DIFF
--- a/lib/pages/full_music_links/full_music_links_screen.dart
+++ b/lib/pages/full_music_links/full_music_links_screen.dart
@@ -43,14 +43,14 @@ class _FullMusicLinksScreenState extends State<FullMusicLinksScreen> with TextPr
     theme = Theme.of(context);
     return Scaffold(
       backgroundColor: theme.scaffoldBackgroundColor,
-      body: _isLoading
-          ? Container(
-              decoration: BoxDecoration(color: theme.scaffoldBackgroundColor),
-              constraints: const BoxConstraints.expand(width: double.infinity, height: double.infinity),
-              child: const LoaderWidget())
-          : Stack(
-              children: [
-                SingleChildScrollView(
+      body: Stack(
+        children: [
+          _isLoading
+              ? Container(
+                  decoration: BoxDecoration(color: theme.scaffoldBackgroundColor),
+                  constraints: const BoxConstraints.expand(width: double.infinity, height: double.infinity),
+                  child: const LoaderWidget())
+              : SingleChildScrollView(
                   child: ConstrainedBox(
                     constraints: BoxConstraints(maxHeight: MediaQuery.of(context).size.height),
                     child: Column(
@@ -64,13 +64,13 @@ class _FullMusicLinksScreenState extends State<FullMusicLinksScreen> with TextPr
                     ),
                   ),
                 ),
-                Positioned(
-                  top: MediaQuery.of(context).padding.top + 16,
-                  left: 16,
-                  child: const CustomCloseButton(),
-                ),
-              ],
-            ),
+          Positioned(
+            top: MediaQuery.of(context).padding.top + 16,
+            left: 16,
+            child: const CustomCloseButton(),
+          ),
+        ],
+      ),
       floatingActionButton: _isLoading ? null : FloatingShareButton(widget.url),
     );
   }

--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -27,7 +27,7 @@ class AppRouteTreeHolder {
       routes: [
         _DefaultGoRoute(
           path: AppRoute.searchSong.route,
-          builder: (context, state) => SearchSongScreen(),
+          builder: (context, state) => const SearchSongScreen(),
         ),
         _DefaultGoRoute(
           path: AppRoute.settings.route,


### PR DESCRIPTION
When opening the full music link page, the search page waited for it to close.
Changing a theme, restarted the app's view and not its data.
As a result, the app still displayed a loader, but had no search page to wait for to close.
The fix was by observing the lifecycle and the applying the same logic we had when we waited for the full music link page to close, essentially fixing this issue.